### PR TITLE
Feature/bind as user

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     build: ./emqx-ldap
     image: emqx-ldap:1.0
     restart: always
+    ports:
+      - 389:389
+      - 636:636
     networks:
       - emqx-bridge
 

--- a/emqx.io.ldif
+++ b/emqx.io.ldif
@@ -32,6 +32,7 @@ objectClass: mqttDevice
 objectClass: mqttSecurity
 uid: mqttuser0001
 isEnabled: TRUE
+mqttAccountName: user1
 mqttPublishTopic: mqttuser0001/pub/1
 mqttPublishTopic: mqttuser0001/pub/+
 mqttPublishTopic: mqttuser0001/pub/#

--- a/emqx.io.ldif
+++ b/emqx.io.ldif
@@ -55,6 +55,7 @@ objectClass: mqttDevice
 objectClass: mqttSecurity
 uid: mqttuser0002
 isEnabled: TRUE
+mqttAccountName: user2
 mqttPublishTopic: mqttuser0002/pub/1
 mqttPublishTopic: mqttuser0002/pub/+
 mqttPublishTopic: mqttuser0002/pub/#

--- a/emqx.schema
+++ b/emqx.schema
@@ -23,10 +23,16 @@ attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4.3 NAME ( 'mqttPubSubTopic' 'mp
 	SUBSTR caseIgnoreSubstringsMatch
 	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
 	USAGE userApplications )
+attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4.4 NAME ( 'mqttAccountName' 'man' )
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	USAGE userApplications )
+
 
 objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4 NAME 'mqttUser'
 	AUXILIARY
-	MAY ( mqttPublishTopic $ mqttSubscriptionTopic $ mqttPubSubTopic) )
+	MAY ( mqttPublishTopic $ mqttSubscriptionTopic $ mqttPubSubTopic $ mqttAccountName) )
 
 objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.2 NAME 'mqttDevice'
 	SUP top

--- a/priv/emqx_auth_ldap.schema
+++ b/priv/emqx_auth_ldap.schema
@@ -143,7 +143,7 @@ end}.
     {datatype, string}
 ]}.
 
-{mapping, "auth.ldap.filters.filters.$num.op", "emqx_auth_ldap.filters", [
+{mapping, "auth.ldap.filters.$num.op", "emqx_auth_ldap.filters", [
     {datatype, {enum, [ "or", "and" ] } }
 ]}.
 

--- a/priv/emqx_auth_ldap.schema
+++ b/priv/emqx_auth_ldap.schema
@@ -144,7 +144,7 @@ end}.
 ]}.
 
 {mapping, "auth.ldap.filters.filters.$num.op", "emqx_auth_ldap.filters", [
-    {datatype, string}
+    {datatype, {enum, [ "or", "and" ] } }
 ]}.
 
 

--- a/priv/emqx_auth_ldap.schema
+++ b/priv/emqx_auth_ldap.schema
@@ -80,13 +80,77 @@
 end}.
 
 {mapping, "auth.ldap.device_dn", "emqx_auth_ldap.device_dn", [
-  {default, "ou=device,dc=emqx,dc=i"},
+  {default, "ou=device,dc=emqx,dc=io"},
   {datatype, string}
 ]}.
 
 {mapping, "auth.ldap.match_objectclass", "emqx_auth_ldap.match_objectclass", [
   {default, "mqttUser"},
   {datatype, string}
+]}.
+
+{mapping, "auth.ldap.custom_base_dn", "emqx_auth_ldap.custom_base_dn", [
+  {default, "${username_attr}=${user},${device_dn}"},
+  {datatype, string}
+]}.
+
+%% auth.ldap.filters.1.key = "objectClass"
+%% auth.ldap.filters.1.value = "mqttUser"
+%% auth.ldap.filters.1.op = "and"
+%% auth.ldap.filters.2.key = "uiAttr"
+%% auth.ldap.filters.2.value "someAttr"
+%% auth.ldap.filters.2.op = "or"
+%% auth.ldap.filters.3.key = "someKey"
+%% auth.ldap.filters.3.value = "someValue"
+%% The configuratation structure sent to the application:
+%%   [{"objectClass","mqttUser"},"and",{"uiAttr","someAttr"},"or",{"someKey","someAttr"}]
+%% The resulting LDAP filter would look like this:
+%% ==> "|(&(objectClass=Class)(uiAttr=someAttr)(someKey=someValue))"
+{translation, "emqx_auth_ldap.filters",
+fun(Conf) ->
+        Settings = cuttlefish_variable:filter_by_prefix("auth.ldap.filters", Conf),
+        Keys = [{Num, {key, V}} || {["auth","ldap","filters", Num, "key"], V} <- Settings],
+        Values = [{Num, {value, V}} || {["auth","ldap","filters", Num, "value"], V} <- Settings],
+        Ops = [{Num, {op, V}} || {["auth","ldap","filters", Num, "op"], V} <- Settings],
+        RawFilters = Keys ++ Values ++ Ops,
+        Filters =
+            lists:foldl(
+              fun({Num,{T,V}}, Acc)->
+                      maps:update_with(Num,
+                                       fun(F)->
+                                               maps:put(T,V,F)
+                                       end,
+                                       #{T=>V}, Acc)
+              end, #{}, RawFilters),
+        Order=lists:usort(maps:keys(Filters)),
+        lists:reverse(
+          lists:foldl(
+            fun(F,Acc)->
+                    case F of
+                        #{key:=K, op:=Op, value:=V} -> [Op,{K,V}|Acc];
+                        #{key:=K, value:=V} -> [{K,V}|Acc]
+                    end
+            end,
+            [],
+            lists:map(fun(K) -> maps:get(K, Filters) end, Order)))
+end}.
+
+{mapping, "auth.ldap.filters.$num.key", "emqx_auth_ldap.filters", [
+    {datatype, string}
+]}.
+
+{mapping, "auth.ldap.filters.$num.value", "emqx_auth_ldap.filters", [
+    {datatype, string}
+]}.
+
+{mapping, "auth.ldap.filters.filters.$num.op", "emqx_auth_ldap.filters", [
+    {datatype, string}
+]}.
+
+
+{mapping, "auth.ldap.bind_as_user", "emqx_auth_ldap.bind_as_user", [
+  {default, false},
+  {datatype, {enum, [true, false]}}
 ]}.
 
 {mapping, "auth.ldap.username.attributetype", "emqx_auth_ldap.username_attr", [

--- a/src/emqx_acl_ldap.erl
+++ b/src/emqx_acl_ldap.erl
@@ -32,9 +32,6 @@
 
 -import(emqx_auth_ldap_cli, [search/3]).
 
--import(emqx_auth_ldap, [replace_vars/2,
-                         compile_filters/2]).
-
 -spec(register_metrics() -> ok).
 register_metrics() ->
     lists:foreach(fun emqx_metrics:new/1, ?ACL_METRICS).
@@ -61,18 +58,7 @@ do_check_acl(#{username := Username}, PubSub, Topic, _NoMatchAction,
                     {"${user}", binary_to_list(Username)},
                     {"${device_dn}", DeviceDn}],
 
-    SubFilters =
-        lists:map(fun({K, V}) ->
-                          {replace_vars(K, ReplaceRules), replace_vars(V, ReplaceRules)};
-                     (Op) ->
-                          Op
-                  end, Filters),
-
-    Filter =
-        case SubFilters of
-            [] -> eldap2:equalityMatch("objectClass", ObjectClass);
-            _List -> compile_filters(SubFilters, [])
-        end,
+    Filter = emqx_auth_ldap:prepare_filter(Filters, UidAttr, ObjectClass, ReplaceRules),
 
     Attribute = case PubSub of
                     publish   -> "mqttPublishTopic";
@@ -82,7 +68,7 @@ do_check_acl(#{username := Username}, PubSub, Topic, _NoMatchAction,
     ?LOG(debug, "[LDAP] search dn:~p filter:~p, attribute:~p",
          [DeviceDn, Filter, Attribute]),
 
-    BaseDN = replace_vars(CustomBaseDN, ReplaceRules),
+    BaseDN = emqx_auth_ldap:replace_vars(CustomBaseDN, ReplaceRules),
 
     case search(BaseDN, Filter, [Attribute, Attribute1]) of
         {error, noSuchObject} ->

--- a/src/emqx_auth_ldap.erl
+++ b/src/emqx_auth_ldap.erl
@@ -29,6 +29,8 @@
 -export([ register_metrics/0
         , check/3
         , description/0
+        , replace_vars/2
+        , compile_filters/2
         ]).
 
 -spec(register_metrics() -> ok).
@@ -37,7 +39,7 @@ register_metrics() ->
 
 check(ClientInfo = #{username := Username, password := Password}, AuthResult,
       State = #{password_attr := PasswdAttr}) ->
-    CheckResult = case lookup_user(Username, State) of
+    CheckResult = case lookup_user(Username, Password, State) of
                       undefined -> {error, not_found};
                       {error, Error} -> {error, Error};
                       Attributes ->
@@ -62,14 +64,67 @@ check(ClientInfo = #{username := Username, password := Password}, AuthResult,
             {stop, AuthResult#{auth_result => ResultCode, anonymous => false}}
     end.
 
-lookup_user(Username, #{username_attr := UidAttr,
-                        match_objectclass := ObjectClass,
-                        device_dn := DeviceDn}) ->
-    Filter = eldap2:equalityMatch("objectClass", ObjectClass),
-    case search(lists:concat([UidAttr,"=", binary_to_list(Username), ",", DeviceDn]), Filter) of
-        {error, noSuchObject} ->
+lookup_user(Username, Password, #{username_attr := UidAttr,
+                                  match_objectclass := ObjectClass,
+                                  device_dn := DeviceDn,
+                                  bind_as_user := BindAsUserRequired,
+                                  custom_base_dn := CustomBaseDN} = Config) ->
+
+    Filters = maps:get(filters, Config, []),
+
+    ReplaceRules = [{"${username_attr}", UidAttr},
+                    {"${user}", binary_to_list(Username)},
+                    {"${device_dn}", DeviceDn}],
+    PasswordString = binary_to_list(Password),
+
+    %% Here the original filter could be appended to the list of filters, like
+    %% ["and",{"objectClass", ObjectClass}]
+    %% ==> "|(&((objectClass=Class)(uiAttr=someAttr))(someKey=someValue))"
+
+    SubFilters =
+        lists:map(fun({K, V}) ->
+                          {replace_vars(K, ReplaceRules), replace_vars(V, ReplaceRules)};
+                     (Op) ->
+                          Op
+                  end, Filters),
+
+    Filter =
+        case SubFilters of
+            [] -> eldap2:equalityMatch("objectClass", ObjectClass);
+            _List -> compile_filters(SubFilters, [])
+        end,
+
+    %% auth.ldap.custom_base_dn = "${username_attr}=${user},${device_dn}"
+    BaseDN = replace_vars(CustomBaseDN, ReplaceRules),
+
+    case {search(BaseDN, Filter), BindAsUserRequired} of
+        {{error, noSuchObject}, _} ->
             undefined;
-        {ok, #eldap_search_result{entries = [Entry]}} ->
+        {{ok, #eldap_search_result{entries = [Entry]}}, true} ->
+            Attributes = Entry#eldap_entry.attributes,
+            case get_value("isEnabled", Attributes) of
+                undefined ->
+                    case emqx_auth_ldap_cli:post_bind(Entry#eldap_entry.object_name, PasswordString) of
+                        ok ->
+                            Attributes;
+                        {error, Reason} ->
+                            {error, Reason}
+                    end;
+                [Val] ->
+                    case list_to_atom(string:to_lower(Val)) of
+                        true ->
+                            case emqx_auth_ldap_cli:post_bind(Entry#eldap_entry.object_name, PasswordString) of
+                                ok ->
+                                    Attributes;
+                                {error, Reason} ->
+                                    {error, Reason}
+                            end;
+                        false ->
+                            {error, username_disabled}
+                    end
+            end;
+
+        {{ok, #eldap_search_result{entries = [Entry]}}, false} ->
             Attributes = Entry#eldap_entry.attributes,
             case get_value("isEnabled", Attributes) of
                 undefined ->
@@ -133,3 +188,35 @@ do_resolve(HashType, Passhash, Password) ->
 
 description() -> "LDAP Authentication Plugin".
 
+compile_filters([{Key, Value}], []) ->
+    compile_equal(Key, Value);
+compile_filters([{K1, V1}, "and", {K2, V2} | Rest], []) ->
+    compile_filters(
+      Rest,
+      eldap2:'and'(compile_equal(K1, V1),
+                   compile_equal(K2, V2)));
+compile_filters([{K1, V1}, "or", {K2, V2} | Rest], []) ->
+    compile_filters(
+      Rest,
+      eldap2:'or'(compile_equal(K1, V1),
+                  compile_equal(K2, V2)));
+compile_filters(["and", {K, V} | Rest], PartialFilter) ->
+    compile_filters(
+      Rest,
+      eldap2:'and'(PartialFilter,
+                   compile_equal(K, V)));
+compile_filters(["or", {K, V} | Rest], PartialFilter) ->
+    compile_filters(
+      Rest,
+      eldap2:'or'(PartialFilter,
+                  compile_equal(K, V)));
+compile_filters([], Filter) ->
+    Filter.
+
+compile_equal(Key, Value) ->
+    eldap2:equalityMatch(Key, Value).
+
+replace_vars(CustomBaseDN, ReplaceRules) ->
+    lists:foldl(fun({Pattern, Substitute}, DN) ->
+                        lists:flatten(string:replace(DN, Pattern, Substitute))
+                end, CustomBaseDN, ReplaceRules).

--- a/src/emqx_auth_ldap_app.erl
+++ b/src/emqx_auth_ldap_app.erl
@@ -31,10 +31,12 @@
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_auth_ldap_sup:start_link(),
     if_enabled([device_dn, match_objectclass,
-                username_attr, password_attr],
+                username_attr, password_attr,
+                filters, custom_base_dn, bind_as_user],
                fun load_auth_hook/1),
     if_enabled([device_dn, match_objectclass,
-                username_attr, password_attr],
+                username_attr, password_attr,
+                filters, custom_base_dn, bind_as_user],
                fun load_acl_hook/1),
     {ok, Sup}.
 

--- a/test/emqx_auth_ldap_bind_as_user_SUITE.erl
+++ b/test/emqx_auth_ldap_bind_as_user_SUITE.erl
@@ -1,0 +1,113 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_auth_ldap_bind_as_user_SUITE).
+
+-compile(export_all).
+-compile(no_warning_export).
+
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(PID, emqx_auth_ldap).
+
+-define(APP, emqx_auth_ldap).
+
+-define(DeviceDN, "ou=test_device,dc=emqx,dc=io").
+
+-define(AuthDN, "ou=test_auth,dc=emqx,dc=io").
+
+all() ->
+    [check_auth,
+     check_acl].
+
+init_per_suite(Config) ->
+    emqx_ct_helpers:start_apps([emqx, emqx_auth_ldap], fun set_special_configs/1),
+    emqx_mod_acl_internal:unload([]),
+    Config.
+
+end_per_suite(_Config) ->
+    emqx_ct_helpers:stop_apps([emqx_auth_ldap, emqx]).
+
+check_auth(_) ->
+    MqttUser1 = #{clientid => <<"mqttuser1">>,
+                  username => <<"user1">>,
+                  password => <<"mqttuser0001">>,
+                  zone => external},
+    MqttUser2 = #{clientid => <<"mqttuser2">>,
+                  username => <<"user2">>,
+                  password => <<"mqttuser0002">>,
+                  zone => external},
+    NonExistUser1 = #{clientid => <<"mqttuser3">>,
+                      username => <<"user3">>,
+                      password => <<"mqttuser0003">>,
+                      zone => external},
+    ct:log("MqttUser: ~p", [emqx_access_control:authenticate(MqttUser1)]),
+    ?assertMatch({ok, #{auth_result := success}}, emqx_access_control:authenticate(MqttUser1)),
+    ?assertMatch({ok, #{auth_result := success}}, emqx_access_control:authenticate(MqttUser2)),
+    ?assertEqual({error, not_authorized}, emqx_access_control:authenticate(NonExistUser1)).
+
+check_acl(_) ->
+    MqttUser = #{clientid => <<"mqttuser1">>, username => <<"user1">>, zone => external},
+    NoMqttUser = #{clientid => <<"mqttuser2">>, username => <<"user7">>, zone => external},
+    allow = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/pub/1">>),
+    allow = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/pub/+">>),
+    allow = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/pub/#">>),
+
+    allow = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/sub/1">>),
+    allow = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/sub/+">>),
+    allow = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/sub/#">>),
+
+    allow = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/pubsub/1">>),
+    allow = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/pubsub/+">>),
+    allow = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/pubsub/#">>),
+    allow = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/pubsub/1">>),
+    allow = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/pubsub/+">>),
+    allow = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/pubsub/#">>),
+
+    deny = emqx_access_control:check_acl(NoMqttUser, publish, <<"mqttuser0001/req/mqttuser0001/+">>),
+    deny = emqx_access_control:check_acl(MqttUser, publish, <<"mqttuser0001/req/mqttuser0002/+">>),
+    deny = emqx_access_control:check_acl(MqttUser, subscribe, <<"mqttuser0001/req/+/mqttuser0002">>),
+    ok.
+
+set_special_configs(emqx) ->
+    application:set_env(emqx, allow_anonymous, false),
+    application:set_env(emqx, enable_acl_cache, false),
+    application:set_env(emqx, acl_nomatch, deny),
+    AclFilePath = filename:join(["test", "emqx_SUITE_data", "acl.conf"]),
+    application:set_env(emqx, acl_file,
+		        emqx_ct_helpers:deps_path(emqx, AclFilePath)),
+    LoadedPluginPath = filename:join(["test", "emqx_SUITE_data", "loaded_plugins"]),
+    application:set_env(emqx, plugins_loaded_file,
+                        emqx_ct_helpers:deps_path(emqx, LoadedPluginPath));
+
+set_special_configs(emqx_auth_ldap) ->
+    application:set_env(emqx_auth_ldap, bind_as_user, true),
+    application:set_env(emqx_auth_ldap, device_dn, "ou=testdevice, dc=emqx, dc=io"),
+    application:set_env(emqx_auth_ldap, custom_base_dn, "${device_dn}"),
+    %% auth.ldap.filters.1.key = mqttAccountName
+    %% auth.ldap.filters.1.value = ${user}
+    %% auth.ldap.filters.1.op = and
+    %% auth.ldap.filters.2.key = objectClass
+    %% auth.ldap.filters.1.value = mqttUser
+    application:set_env(emqx_auth_ldap, filters, [{"mqttAccountName", "${user}"},
+                                                  "and",
+                                                  {"objectClass", "mqttUser"}]);
+
+set_special_configs(_App) ->
+    ok.
+


### PR DESCRIPTION
###  Expose LDAP ports in testing compose
commit 86ab66f6e2351294e1c263c99d3761ba0942c1e3   

    Expose the LDAP ports in the docker-compose used for CI. This way, the
    LDAP container is usable as a standalone testing server and useful for
    manual testing.

### Introduce new LDAP configuration options
commit 41cd1547c95f6a0332fc18c31e6a9b77b7fcde8f
    
    `auth.ldap.custom_base_dn` can be used as a substitute for the
    hard-coded base DN used for both authentication and authorization. The
    hardcoded version mandated to have the user from the connection to exist
    in LDAP under the `uid=` attribute. The new base DN allows for fully
    custom string. Three variables can be used and they will be substituted
    before sending the DN to LDAP.
      - `${username_attr}` will be substitured to the value defined in
      `auth.ldap.username.attributetype`.
      - `${user}` is substituted to the username provided by the client.
      - `${device_dn}` is substituted to the string defined in
      `auth.ldap.device_dn`
    
    Additionaly a typo was fixed in the `auth.ldap.device_dn` default
    string.
    
    `auth.ldap.filters.$num.{key|value|op}` can be used to specify
    additional filter values compared to the predefined
    `objectClass=Class`. At least the `key` and `value` must be present and
    they represent an equality check. At each level (`$num`) an optional
    operation can be defined (currently only "and" or "or"). This applies to
    all the previously defined filters in a left-associative manner. There
    is no way to express hierarchy. An example can be found in a comment in
    the schema file. The default option is the old behaviour if no filter is
    present in the config.
    
    `auth.ldap.bind_as_user` must be set to `true` if a second bind
    operation is required to authenticate the user provided in the
    client. Otherwise the user will only used for authorization. If this
    option is omitted or set to `false`, then the old behaviour is
    used.

### Add support for "Bind as User" feature
commit 0339b835823db463b359dcedaa82ab1450f0ad4a
    
    In some cases, the Base DN to authenticate the user provided by the
    connection needs to be obtained by an LDAP search. This change makes it
    possible to do so in EMQx.
    
    The substitution of variables in the configuration paramters are
    performed unconditionally for both the user and acl processing. This was
    necessary to remove the hardcoded Base DN generation and still preserve
    backward compatibility. All users benefit from this small improvement,
    regardless whether they need the "Bind As User" feature.
    
    The substitution processing is not optimised, but the lists are expected
    to be very small or empty, thus no major performance degradation is
    expected.
    
    In the LDAP cli implementation, an extra bind is introduced, if
    `bind_as_user` is set to true. This was necessary to reset the last bind
    to the root user before executing the query.
    
    A major consideration was taken to preserve backward compatibility for
    users not opting for the feature. No configuration changes are
    necessary, but the `priv/eqmx_auth_ldap.schema` needs to be updated to
    pick up the proper default values.

### Add additional LDAP schema attribute
commit 120162eab02845db9e95075661875f581574896c
    
    Add an extra schema attribute to the LDAP schema of EMQx. This was used
    for testing and could be removed, if it interferes with policies.